### PR TITLE
issue: Titlesonly in second-level subtree

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -9,9 +9,11 @@ subtrees:
 - caption: Example
   entries:
   - file: example/index
-    entries:
-    - file: example/subfolder/page
-    - glob: example/globfolder/*
+    subtrees:
+    - titlesonly: True
+      entries:
+      - file: example/subfolder/page
+      - glob: example/globfolder/*
 - caption: Links
   entries:
   - title: GitHub Repository

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,19 +4,20 @@ project = "Sphinx External ToC"
 copyright = "2021, Executable Book Project"
 author = "Executable Book Project"
 
-extensions = ["myst_parser", "sphinx_external_toc"]
+extensions = ["myst_parser", "sphinx_external_toc", "sphinx_rtd_theme"]
 
 myst_enable_extensions = ["colon_fence", "html_image"]
 
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 external_toc_exclude_missing = True
 
-html_theme = "sphinx_book_theme"
+#html_theme = "sphinx_book_theme"
+html_theme = "sphinx_rtd_theme"
 html_title = project
-html_theme_options = {
-    "home_page_in_toc": True,
-    "use_edit_page_button": True,
-    "repository_url": "https://github.com/executablebooks/sphinx-external-toc",
-    "repository_branch": "main",
-    "path_to_docs": "docs",
-}
+# html_theme_options = {
+#    "home_page_in_toc": True,
+#    "use_edit_page_button": True,
+#    "repository_url": "https://github.com/executablebooks/sphinx-external-toc",
+#    "repository_branch": "main",
+#    "path_to_docs": "docs",
+#}

--- a/docs/example/index.md
+++ b/docs/example/index.md
@@ -2,3 +2,11 @@
 
 These pages provide an example of different aspects of the ToC.
 See this projects `_toc.yml` for how they are added.
+
+## Something you'll want to know
+
+Replace with something important and informative here.
+
+## Details you'll likely skip
+
+No code, no read.

--- a/docs/example/subfolder/page.md
+++ b/docs/example/subfolder/page.md
@@ -1,3 +1,11 @@
 # Sub-section Page
 
 This is a page of a subsection.
+
+## First second-level heading
+
+Blah.
+
+## Second second-level heading
+
+Blah again.

--- a/sphinx_external_toc/__init__.py
+++ b/sphinx_external_toc/__init__.py
@@ -15,6 +15,7 @@ def setup(app: "Sphinx") -> dict:
         InsertToctrees,
         TableofContents,
         add_changed_toctrees,
+        enforce_titlesonly,
         ensure_index_file,
         parse_toc_to_env,
     )
@@ -22,12 +23,14 @@ def setup(app: "Sphinx") -> dict:
     # variables
     app.add_config_value("external_toc_path", "_toc.yml", "env")
     app.add_config_value("external_toc_exclude_missing", False, "env")
+    app.add_config_value("external_toc_enforce_titlesonly", False, "env")
 
     # Note: this needs to occur after merge_source_suffix event (priority 800)
     # this cannot be a builder-inited event, since if we change the master_doc
     # it will always mark the config as changed in the env setup and re-build everything
     app.connect("config-inited", parse_toc_to_env, priority=900)
     app.connect("env-get-outdated", add_changed_toctrees)
+    app.connect("doctree-resolved", enforce_titlesonly)
     app.add_directive("tableofcontents", TableofContents)
     app.add_transform(InsertToctrees)
     app.connect("build-finished", ensure_index_file)

--- a/tests/_toc_files/titlesonly.yml
+++ b/tests/_toc_files/titlesonly.yml
@@ -1,0 +1,14 @@
+root: intro
+entries:
+- file: folder/doc1
+- file: folder/doc2
+- file: folder/doc3
+  subtrees:
+  - titlesonly: True
+    hidden: False
+    entries:
+    - file: folder/subfolder/doc4
+    - glob: folder/globfolder/*
+meta:
+  create_files:
+  - folder/globfolder/glob1

--- a/tests/test_parsing/test_create_toc_dict_titlesonly_.yml
+++ b/tests/test_parsing/test_create_toc_dict_titlesonly_.yml
@@ -1,0 +1,14 @@
+entries:
+- file: folder/doc1
+- file: folder/doc2
+- entries:
+  - file: folder/subfolder/doc4
+  - glob: folder/globfolder/*
+  file: folder/doc3
+  options:
+    hidden: false
+    titlesonly: true
+meta:
+  create_files:
+  - folder/globfolder/glob1
+root: intro

--- a/tests/test_parsing/test_file_to_sitemap_titlesonly_.yml
+++ b/tests/test_parsing/test_file_to_sitemap_titlesonly_.yml
@@ -1,0 +1,44 @@
+documents:
+  folder/doc1:
+    docname: folder/doc1
+    subtrees: []
+    title: null
+  folder/doc2:
+    docname: folder/doc2
+    subtrees: []
+    title: null
+  folder/doc3:
+    docname: folder/doc3
+    subtrees:
+    - caption: null
+      hidden: false
+      items:
+      - folder/subfolder/doc4
+      - folder/globfolder/*
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+  folder/subfolder/doc4:
+    docname: folder/subfolder/doc4
+    subtrees: []
+    title: null
+  intro:
+    docname: intro
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - folder/doc1
+      - folder/doc2
+      - folder/doc3
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: false
+    title: null
+meta:
+  create_files:
+  - folder/globfolder/glob1
+root: intro

--- a/tests/test_tools/test_file_to_sitemap_titlesonly_.yml
+++ b/tests/test_tools/test_file_to_sitemap_titlesonly_.yml
@@ -1,0 +1,10 @@
+- _toc.yml
+- folder
+- folder/doc1.rst
+- folder/doc2.rst
+- folder/doc3.rst
+- folder/globfolder
+- folder/globfolder/glob1.rst
+- folder/subfolder
+- folder/subfolder/doc4.rst
+- intro.rst


### PR DESCRIPTION
Revise the example document to demonstrate the
trouble I'm having (at least with the RTD theme)
to set titlesonly for a second-level page.